### PR TITLE
Add dynamic default output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains a simple crawler script for exporting the contents of a
    If you see `ModuleNotFoundError: No module named 'bs4'`, install the dependencies first.
 
 2. Run the crawler. Provide the URL you want to crawl (defaults to
-   `https://allmendina.de`).
+   `https://allmendina.de`):
    If no `--outdir` is given, a directory named
    `output_<domain>_<timestamp>` will be created automatically (e.g.
    `output_art-institut.de_2025_07_23_13.15.12`).

--- a/README.md
+++ b/README.md
@@ -11,13 +11,20 @@ This repository contains a simple crawler script for exporting the contents of a
    If you see `ModuleNotFoundError: No module named 'bs4'`, install the dependencies first.
 
 2. Run the crawler. Provide the URL you want to crawl (defaults to
-   `https://allmendina.de`):
+   `https://allmendina.de`).
+   If no `--outdir` is given, a directory named
+   `output_<domain>_<timestamp>` will be created automatically (e.g.
+   `output_art-institut.de_2025_07_23_13.15.12`).
    ```bash
-   python crawler.py https://allmendina.de --outdir output
+   python crawler.py https://allmendina.de
 
    ```
-   The resulting Markdown files will be written to the specified directory.
-   Any images referenced on the pages are downloaded to `output/images`
+   To explicitly set the output directory:
+   ```bash
+   python crawler.py https://allmendina.de --outdir output
+   ```
+   The resulting Markdown files will be written to the chosen directory.
+   Any images referenced on the pages are downloaded to `<outdir>/images`
    with simplified names (e.g. `img1.jpg`). A mapping of original URLs
    is stored in `image_sources.txt` within that folder.
 

--- a/crawler.py
+++ b/crawler.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import re
+import time
 from collections import deque
 from urllib.parse import urljoin, urlparse
 
@@ -16,6 +17,14 @@ except ModuleNotFoundError:
 def slugify(text: str) -> str:
     text = re.sub(r'\W+', '-', text.lower())
     return text.strip('-') or 'index'
+
+
+def generate_outdir(base_url: str) -> str:
+    """Create a default output directory name from the domain and current time."""
+    parsed = urlparse(base_url if '://' in base_url else f'https://{base_url}')
+    domain = (parsed.netloc or parsed.path).split('/')[0]
+    timestamp = time.strftime('%Y_%m_%d_%H.%M.%S')
+    return f'output_{domain}_{timestamp}'
 
 
 def extract_links(soup, base_url, visited):
@@ -125,10 +134,11 @@ def main():
         help='Base URL to crawl (default: %(default)s)'
     )
     parser.add_argument(
-        '--outdir', default='output', help='Directory for Markdown output'
+        '--outdir', help='Directory for Markdown output'
     )
     args = parser.parse_args()
-    crawl(args.url, args.outdir)
+    outdir = args.outdir or generate_outdir(args.url)
+    crawl(args.url, outdir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- generate an output folder name from the URL and current time
- let `--outdir` be optional and update docs to describe the new behaviour

## Testing
- `python -m py_compile crawler.py`
- `pip install -r requirements.txt`
- `python crawler.py -h`

------
https://chatgpt.com/codex/tasks/task_e_6880c2089584832f990cfa6f350d8739