### PR TITLE
Remove default URL from crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,17 @@ This repository contains a simple crawler script for exporting the contents of a
    ```
    If you see `ModuleNotFoundError: No module named 'bs4'`, install the dependencies first.
 
-2. Run the crawler. Provide the URL you want to crawl (defaults to
-   `https://allmendina.de`):
+2. Run the crawler. Provide the URL you want to crawl:
    If no `--outdir` is given, a directory named
    `output_<domain>_<timestamp>` will be created automatically (e.g.
    `output_art-institut.de_2025_07_23_13.15.12`).
    ```bash
-   python crawler.py https://allmendina.de
+   python crawler.py https://example.com
 
    ```
    To explicitly set the output directory:
    ```bash
-   python crawler.py https://allmendina.de --outdir output
+   python crawler.py https://example.com --outdir output
    ```
    The resulting Markdown files will be written to the chosen directory.
    Any images referenced on the pages are downloaded to `<outdir>/images`

--- a/crawler.py
+++ b/crawler.py
@@ -121,17 +121,14 @@ def crawl(base_url, outdir='output'):
             queue.append(link)
 
 
-DEFAULT_URL = "https://allmendina.de"
-
-
 
 def main():
     parser = argparse.ArgumentParser(
         description='Crawl a website and output Markdown files.'
     )
     parser.add_argument(
-        'url', nargs='?', default=DEFAULT_URL,
-        help='Base URL to crawl (default: %(default)s)'
+        'url',
+        help='Base URL to crawl'
     )
     parser.add_argument(
         '--outdir', help='Directory for Markdown output'


### PR DESCRIPTION
## Summary
- remove default URL constant from `crawler.py`
- make the URL argument mandatory
- update docs with new usage examples

## Testing
- `python -m py_compile crawler.py`
- `python crawler.py --help`
- `python crawler.py https://example.com --outdir test_output --help`


------
https://chatgpt.com/codex/tasks/task_e_6880c8579430832fa2c782a9c67fd432